### PR TITLE
Make merge fieldnames case insensitive.

### DIFF
--- a/MailMerge/CommandLine/ParseArgs.cs
+++ b/MailMerge/CommandLine/ParseArgs.cs
@@ -33,7 +33,7 @@ namespace MailMerge.CommandLine
         static (Program.Command, (FileInfo, FileInfo)[], Dictionary<string, string>) ParseArgsForMerge(IEnumerable<string> cargs, Program.Command command)
         {
             var files = new List<(FileInfo, FileInfo)>();
-            var mergefields = new Dictionary<string, string>();
+            var mergefields = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             var oddeven = OddEven.Even;
             string lastin = null;
             foreach (var arg in cargs)


### PR DESCRIPTION
Fixes issue #4

> The names of fields are alphabetic tokens [Example: Some field-type names are ASK, COMMENTS, NEXT, and SET. end example]. These tokens are called field-type names. Field-type names are case-insensitive. [Example: The field-type names DATE, Date, dAtE, and date are equivalent. end example]